### PR TITLE
Fix type declaration for Monad's then function

### DIFF
--- a/notes/l1/basics.md
+++ b/notes/l1/basics.md
@@ -1381,7 +1381,7 @@ class Monad m where
     fail :: String -> m a   -- called when pattern binding fails
     fail s = error s        -- default is to throw exception
 
-    (>>) :: m a -> m b -> m a
+    (>>) :: m a -> m b -> m b
     m >> k = m >>= \_ -> k
 ~~~~
 


### PR DESCRIPTION
The type in the documentation is incorrect for (>>) function. It
ignores their input and just returns a predetermined monadic value.
